### PR TITLE
Dependencies version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 packages
 pubspec.lock
+.buildlog
+example/browser/out/_from_packages/logging_handlers/src/client/loggerui.dart
+example/browser/out/_from_packages/logging_handlers/src/client/loggerui.dart.map
+example/browser/out/test.dart
+example/browser/out/test.dart.map
+example/browser/out/test.html
+example/browser/out/test.html_bootstrap.dart
+test/server/mylog1.txt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 logging_handlers
 ================
 
+[![Build Status](https://drone.io/github.com/DanieleSalatti/logging_handlers/status.png)](https://drone.io/github.com/DanieleSalatti/logging_handlers/latest)
+
 A package of logging handlers, for either the client or server, that uses the 
 Dart SDK's [`logging` pub package](http://pub.dartlang.org/packages/logging)
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,17 +1,14 @@
 name: logging_handlers
-version: 0.5.0+1
 author: Chris Buckett <chrisbuckett@gmail.com>
 description: A selection of handlers that you can use as targets for the "logger" pub package.  Stop using print() and start using logger.info()
 homepage: https://github.com/chrisbu/logging_handlers
-environment:
-  sdk: '>=0.5.0+1.r21823'
 dependencies:
-  intl: 0.5.0+1
-  web_ui: 0.4.6+2
-  logging: 0.5.0+1
+  intl: any
+  logging: any
+  web_ui: any
 dev_dependencies:
-  unittest: 0.5.0+1
-  browser: '>=0.5.0+1'
+  browser: any
+  unittest: any
 
 #dependencies:
 #  unittest: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,12 +6,12 @@ homepage: https://github.com/chrisbu/logging_handlers
 environment:
   sdk: '>=0.5.13+1'
 dependencies:
-  intl: 0.5.13
-  logging: 0.5.13
-  web_ui: 0.4.9+5
+  intl: '>=0.5.13'
+  logging: '>=0.5.13'
+  web_ui: '>=0.4.9+5'
 dev_dependencies:
-  browser: 0.5.13
-  unittest: 0.5.13
+  browser: '>=0.5.13'
+  unittest: '>=0.5.13'
 
 #dependencies:
 #  unittest: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,17 @@
 name: logging_handlers
+version: 0.5.13
 author: Chris Buckett <chrisbuckett@gmail.com>
 description: A selection of handlers that you can use as targets for the "logger" pub package.  Stop using print() and start using logger.info()
 homepage: https://github.com/chrisbu/logging_handlers
+environment:
+  sdk: '>=0.5.13+1'
 dependencies:
-  intl: any
-  logging: any
-  web_ui: any
+  intl: 0.5.13
+  logging: 0.5.13
+  web_ui: 0.4.9+5
 dev_dependencies:
-  browser: any
-  unittest: any
+  browser: 0.5.13
+  unittest: 0.5.13
 
 #dependencies:
 #  unittest: any


### PR DESCRIPTION
Hi Chris

I modified the pubspec.yaml specifying newer dependencies' versions. This is to fix a problem that I had since dart:uri has been removed but logging_handlers was preventing web_ui (which used to rely on dart:ui) to be updated so everything stopped working.

It's the first time that I try a pull request so hope everything works.

Let me know if you want me to change/fix something and do a pull request again. :)
- Daniele
