### PR TITLE
Fixes for 0.8.7

### DIFF
--- a/build.dart
+++ b/build.dart
@@ -1,6 +1,5 @@
 import 'package:web_ui/component_build.dart';
-import 'dart:io';
 
 void main() {
-  build(new Options().arguments, ['example/browser/test.html']);
+  build([], ['example/browser/test.html']);
 }

--- a/example/browser/test.dart
+++ b/example/browser/test.dart
@@ -12,7 +12,7 @@ main() {
    attachXLoggerUi();
    
    
-   query("#click").onClick.listen((_) {
+   querySelector("#click").onClick.listen((_) {
      logger.info("Button clicked");
      debug("Foo", "loggerui");
    });

--- a/example/server/test.dart
+++ b/example/server/test.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:logging_handlers/server_logging_handlers.dart';
 import 'package:logging/logging.dart';
  

--- a/lib/browser_logging_handlers.dart
+++ b/lib/browser_logging_handlers.dart
@@ -1,7 +1,7 @@
 library browser;
 
 import 'dart:html';
-import 'dart:async'; 
+import 'dart:async' show Timer; 
 import 'logging_handlers_shared.dart';
 import 'package:logging/logging.dart';
 export 'logging_handlers_shared.dart';
@@ -14,7 +14,7 @@ export 'logging_handlers_shared.dart';
  */
 void attachXLoggerUi([bool addPrintHandler=true]) {
   Timer.run(() {
-    var loggerComponents = queryAll("div[is=x-loggerui]");
+    var loggerComponents = querySelectorAll("div[is=x-loggerui]");
     print(loggerComponents);
     var listener = Logger.root.onRecord.asBroadcastStream();
     loggerComponents.forEach((component) {

--- a/lib/logging_handlers_shared.dart
+++ b/lib/logging_handlers_shared.dart
@@ -1,7 +1,5 @@
 library logging_handlers_shared;
 
-import 'dart:json';
-
 import 'package:logging/logging.dart';
 import 'package:intl/intl.dart';
 

--- a/lib/server_logging_handlers.dart
+++ b/lib/server_logging_handlers.dart
@@ -1,9 +1,6 @@
 library server;
 
 import 'dart:io';
-import 'dart:isolate';
-import 'dart:collection';
-import 'dart:async';
 
 import 'package:logging/logging.dart';
 

--- a/lib/src/shared/map_transformer.dart
+++ b/lib/src/shared/map_transformer.dart
@@ -1,7 +1,7 @@
 part of logging_handlers_shared;
 
 /**
- * Transforms a Log Record into a Map that can be stringified by JSON.stringify()  
+ * Transforms a Log Record into a Map that can be stringified by JSON.encode()  
  */
 class MapTransformer implements LogRecordTransformer {
   
@@ -15,8 +15,8 @@ class MapTransformer implements LogRecordTransformer {
     map["time"] = logRecord.time != null ? logRecord.time.toString() : null;
     map["sequenceNumber"] = logRecord.sequenceNumber;
     map["loggerName"] = logRecord.loggerName;
-    map["exceptionText"] = logRecord.exceptionText;
-    map["exception"] = logRecord.exception != null ? logRecord.exception.toString() : null;    
+    map["stackTrace"] = logRecord.stackTrace != null ? logRecord.stackTrace.toString() : null;
+    map["error"] = logRecord.error != null ? logRecord.error.toString() : null;    
     return map;
   }
 }

--- a/lib/src/shared/string_transformer.dart
+++ b/lib/src/shared/string_transformer.dart
@@ -21,7 +21,7 @@ class StringTransformer implements LogRecordTransformer {
   /// Outputs the logger sequence
   static const SEQ = "%s"; // logger sequence
   static const EXCEPTION = "%x"; // logger exception
-  static const EXCEPTION_TEXT = "%e"; // logger exception message
+  static const STACK_TRACE = "%e"; // logger stack trace
   static const TAB = "\t";
   static const NEW_LINE = "\n";
   
@@ -48,7 +48,7 @@ class StringTransformer implements LogRecordTransformer {
   DateFormat dateFormat;
   
   /// Contains the regexp pattern
-  static final _regexp = new RegExp("($LEVEL|$MESSAGE|$NAME|$TIME|$SEQ|$EXCEPTION|$EXCEPTION_TEXT)");
+  static final _regexp = new RegExp("($LEVEL|$MESSAGE|$NAME|$TIME|$SEQ|$EXCEPTION|$STACK_TRACE)");
   
   StringTransformer({
       String this.messageFormat : StringTransformer.DEFAULT_MESSAGE_FORMAT,
@@ -62,7 +62,7 @@ class StringTransformer implements LogRecordTransformer {
    * [exceptionFormatSuffix] and [timestampFormat] pattern.
    */
   String transform(LogRecord logRecord) {
-    var formatString = logRecord.exception == null ? 
+    var formatString = logRecord.error == null ? 
                                   messageFormat : 
                                   messageFormat+exceptionFormatSuffix;
     
@@ -92,10 +92,10 @@ class StringTransformer implements LogRecordTransformer {
           case SEQ:
             return logRecord.sequenceNumber.toString();
           case EXCEPTION: 
-            if (logRecord.exception != null) return logRecord.exception.toString();
+            if (logRecord.error != null) return logRecord.error.toString();
             break;
-          case EXCEPTION_TEXT:
-            return logRecord.exceptionText;
+          case STACK_TRACE:
+            if (logRecord.stackTrace != null) return logRecord.stackTrace.toString();
         }
       }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,14 +4,14 @@ author: Chris Buckett <chrisbuckett@gmail.com>
 description: A selection of handlers that you can use as targets for the "logger" pub package.  Stop using print() and start using logger.info()
 homepage: https://github.com/chrisbu/logging_handlers
 environment:
-  sdk: '>=0.8.7'
+  sdk: '>=0.8.10+6 <2.0.0'
 dependencies:
-  intl: '>=0.8.7'
-  web_ui: '>=0.4.23'
-  logging: '>=0.8.7'
+  intl: '>=0.9.0 <0.10.0'
+  web_ui: '>=0.4.27'
+  logging: '>=0.9.0 <0.10.0'
 dev_dependencies:
-  unittest: '>=0.8.7'
-  browser: '>=0.8.7'
+  unittest: '>=0.9.0 <0.10.0'
+  browser: '>=0.9.0 <0.10.0'
 
 #dependencies:
 #  unittest: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,14 +4,14 @@ author: Chris Buckett <chrisbuckett@gmail.com>
 description: A selection of handlers that you can use as targets for the "logger" pub package.  Stop using print() and start using logger.info()
 homepage: https://github.com/chrisbu/logging_handlers
 environment:
-  sdk: '>=0.5.0+1.r21823'
+  sdk: '>=0.8.5'
 dependencies:
-  intl: 0.5.0+1
-  web_ui: 0.4.6+2
-  logging: 0.5.0+1
+  intl: '>=0.8.5'
+  web_ui: '>=0.4.23'
+  logging: '>=0.8.5'
 dev_dependencies:
-  unittest: 0.5.0+1
-  browser: '>=0.5.0+1'
+  unittest: '>=0.8.5'
+  browser: '>=0.8.5'
 
 #dependencies:
 #  unittest: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,14 +4,14 @@ author: Chris Buckett <chrisbuckett@gmail.com>
 description: A selection of handlers that you can use as targets for the "logger" pub package.  Stop using print() and start using logger.info()
 homepage: https://github.com/chrisbu/logging_handlers
 environment:
-  sdk: '>=0.8.5'
+  sdk: '>=0.8.7'
 dependencies:
-  intl: '>=0.8.5'
+  intl: '>=0.8.7'
   web_ui: '>=0.4.23'
-  logging: '>=0.8.5'
+  logging: '>=0.8.7'
 dev_dependencies:
-  unittest: '>=0.8.5'
-  browser: '>=0.8.5'
+  unittest: '>=0.8.7'
+  browser: '>=0.8.7'
 
 #dependencies:
 #  unittest: any

--- a/test/shared/shared_test.dart
+++ b/test/shared/shared_test.dart
@@ -2,8 +2,10 @@ library shared_test;
 
 import 'package:logging_handlers/logging_handlers_shared.dart'; 
 import 'package:unittest/unittest.dart';
+import 'package:unittest/mock.dart';
 import 'package:logging/logging.dart';
-import 'dart:json';
+import 'package:intl/intl.dart';
+import 'dart:convert';
 
 part 'src/transformer_tests.dart';
 

--- a/test/shared/src/transformer_tests.dart
+++ b/test/shared/src/transformer_tests.dart
@@ -1,6 +1,10 @@
 part of shared_test;
 
-
+class MockStackTrace extends Mock implements StackTrace {
+  String _text;
+  MockStackTrace(String this._text);
+  toString() => _text;
+}
 
 runTransformerTests() {
   group("transformers", () {
@@ -31,49 +35,57 @@ class TestFormatterImpl extends LogRecordTransformer { }
 
 
 runStringTransformerTests() {
+  print(new MockStackTrace("Exception text").toString());
   test("defaults", () {
     var message = "I am a message";
     var loggerName = "my.logger";
-    var time = DateTime.parse("2012-02-27 13:27:00.123456z");
-    var logRecord = new LogRecord(Level.INFO, message, loggerName, time);
+    //var time = DateTime.parse("2012-02-27 13:27:00.123456z");
+    var time = new DateTime.now();
+    var formatter = new DateFormat('yyyy-MM-dd');
+    var logRecord = new LogRecord(Level.INFO, message, loggerName);
     
     var impl = new StringTransformer();
     expect(impl.transform(logRecord),
-        equals("2012-02-27 13:27:00.123Z\tmy.logger\t[INFO]:\tI am a message"));
+        contains("\tmy.logger\t[INFO]:\tI am a message"));
+    expect(impl.transform(logRecord),
+        startsWith(formatter.format(time)));
   });
   
   test("defaults with exception", () {
     var message = "I am a message";
     var loggerName = "my.logger";
-    var time = DateTime.parse("2012-02-27 13:27:00.123456z");
+    //var time = DateTime.parse("2012-02-27 13:27:00.123456z");
+    var time = new DateTime.now();
+    var formatter = new DateFormat('yyyy-MM-dd');
     var exception = new Exception("I am an exception");
     var logRecord = new LogRecord(Level.INFO, 
         message, 
         loggerName, 
-        time, 
         exception,
-        "Exception text");
+        new MockStackTrace("Exception text"));
     
     var impl = new StringTransformer();
     expect(impl.transform(logRecord),
-        equals("2012-02-27 13:27:00.123Z\tmy.logger\t[INFO]:\tI am a message\nException text\nException: I am an exception"));
+        contains("\tmy.logger\t[INFO]:\tI am a message\nException text\nException: I am an exception"));
+    expect(impl.transform(logRecord),
+        startsWith(formatter.format(time)));
   });  
   
   test("custom formats", () {
     var message = "I am a message";
     var loggerName = "my.logger";
-    var time = DateTime.parse("2012-02-27 13:27:00.123456z");
+    //var time = DateTime.parse("2012-02-27 13:27:00.123456z");
+    var time = new DateTime.now();
+    var formatter = new DateFormat('dd-MM-yyyy');
     var exception = new Exception("I am an exception");
     var logRecordNoException = new LogRecord(Level.FINEST, 
         message, 
-        loggerName,
-        time);
+        loggerName);
     var logRecordWithException = new LogRecord(Level.FINEST, 
         message, 
         loggerName, 
-        time, 
         exception,
-        "Exception text");
+        new MockStackTrace("Exception text"));
     
     var impl = new StringTransformer(messageFormat: "%s %t %n[%p]: %m", exceptionFormatSuffix: " %e %x", timestampFormat: "dd-MM-yyyy");
     // Note - this prints the exception message with a sequence number.
@@ -81,9 +93,9 @@ runStringTransformerTests() {
     // relation to other tests.  For that reason, we'll check that the logged
     // output "contains" the expected string without the sequence number prefix 
     expect(impl.transform(logRecordNoException),
-        contains(" 27-02-2012 my.logger[FINEST]: I am a message"));
+        contains(" ${formatter.format(time)} my.logger[FINEST]: I am a message"));
     expect(impl.transform(logRecordWithException),
-        contains(" 27-02-2012 my.logger[FINEST]: I am a message Exception text Exception: I am an exception"));
+        contains(" ${formatter.format(time)} my.logger[FINEST]: I am a message Exception text Exception: I am an exception"));
     
   });  
 }
@@ -92,20 +104,19 @@ runMapTransformerTests() {
   test("defaults", () {
     var message = "I am a message";
     var loggerName = "my.logger";
-    var time = DateTime.parse("2012-02-27 13:27:00.123456z");
-    var logRecord = new LogRecord(Level.INFO, message, loggerName, time);
+    var logRecord = new LogRecord(Level.INFO, message, loggerName);
     
     var impl = new MapTransformer();
     var map = impl.transform(logRecord); // convert the logRecord to a map    
-    String json = stringify(map); // convert the map to json with dart:json
-    Map map2 = parse(json); // convert the json back to a map
+    String json = JSON.encode(map); // convert the map to json with dart:convert
+    Map map2 = JSON.decode(json); // convert the json back to a map
     
     expect(map2["message"], equals(logRecord.message));
     expect(map2["loggerName"], equals(logRecord.loggerName));
     expect(map2["level"], equals(logRecord.level.name));
     expect(map2["sequenceNumber"], equals(logRecord.sequenceNumber));
-    expect(map2["exceptionText"], isNull);
-    expect(map2["exception"], isNull);
+    expect(map2["stackTrace"], isNull);
+    expect(map2["error"], isNull);
     expect(map2["time"], equals(logRecord.time.toString()));
     
   });
@@ -113,26 +124,24 @@ runMapTransformerTests() {
   test("defaults with exception", () {
     var message = "I am a message";
     var loggerName = "my.logger";
-    var time = DateTime.parse("2012-02-27 13:27:00.123456z");
     var exception = new Exception("I am an exception");
     var logRecord = new LogRecord(Level.INFO, 
         message, 
         loggerName, 
-        time, 
         exception,
-        "Exception text");
+        new MockStackTrace("Exception text"));
     
     var impl = new MapTransformer();
     var map = impl.transform(logRecord); // convert the logRecord to a map    
-    String json = stringify(map); // convert the map to json with dart:json
-    Map map2 = parse(json); // convert the json back to a map
+    String json = JSON.encode(map); // convert the map to json with dart:convert
+    Map map2 = JSON.decode(json); // convert the json back to a map
     
     expect(map2["message"], equals(logRecord.message));
     expect(map2["loggerName"], equals(logRecord.loggerName));
     expect(map2["level"], equals(logRecord.level.name));
     expect(map2["sequenceNumber"], equals(logRecord.sequenceNumber));
-    expect(map2["exceptionText"], equals(logRecord.exceptionText));
-    expect(map2["exception"], equals(logRecord.exception.toString()));
+    expect(map2["stackTrace"], equals(logRecord.stackTrace.toString()));
+    expect(map2["error"], equals(logRecord.error.toString()));
     expect(map2["time"], equals(logRecord.time.toString()));
   });  
 }


### PR DESCRIPTION
Unfortunately logging_handlers is unusable in Dart SDK 0.8.7 since 'dart:json' has been removed.
I've taken this as excuse to update the library and remove deprecated stuff.

I'v only touched the shared and server handlers, so the web example is still throwing an exception like discussed in #2.
