### PR TITLE
use dart:convert to replace dart:json

### DIFF
--- a/lib/logging_handlers_shared.dart
+++ b/lib/logging_handlers_shared.dart
@@ -1,7 +1,5 @@
 library logging_handlers_shared;
 
-import 'dart:json';
-
 import 'package:logging/logging.dart';
 import 'package:intl/intl.dart';
 

--- a/test/shared/shared_test.dart
+++ b/test/shared/shared_test.dart
@@ -3,7 +3,7 @@ library shared_test;
 import 'package:logging_handlers/logging_handlers_shared.dart'; 
 import 'package:unittest/unittest.dart';
 import 'package:logging/logging.dart';
-import 'dart:json';
+import 'dart:convert';
 
 part 'src/transformer_tests.dart';
 

--- a/test/shared/src/transformer_tests.dart
+++ b/test/shared/src/transformer_tests.dart
@@ -96,10 +96,10 @@ runMapTransformerTests() {
     var logRecord = new LogRecord(Level.INFO, message, loggerName, time);
     
     var impl = new MapTransformer();
-    var map = impl.transform(logRecord); // convert the logRecord to a map    
-    String json = stringify(map); // convert the map to json with dart:json
-    Map map2 = parse(json); // convert the json back to a map
-    
+    var map = impl.transform(logRecord); // convert the logRecord to a map
+    String json = JSON.encode(map); // convert the map to json with dart:json
+    Map map2 = JSON.decode(json); // convert the json back to a map
+
     expect(map2["message"], equals(logRecord.message));
     expect(map2["loggerName"], equals(logRecord.loggerName));
     expect(map2["level"], equals(logRecord.level.name));
@@ -123,10 +123,10 @@ runMapTransformerTests() {
         "Exception text");
     
     var impl = new MapTransformer();
-    var map = impl.transform(logRecord); // convert the logRecord to a map    
-    String json = stringify(map); // convert the map to json with dart:json
-    Map map2 = parse(json); // convert the json back to a map
-    
+    var map = impl.transform(logRecord); // convert the logRecord to a map
+    String json = JSON.encode(map); // convert the map to json with dart:json
+    Map map2 = JSON.decode(json); // convert the json back to a map
+
     expect(map2["message"], equals(logRecord.message));
     expect(map2["loggerName"], equals(logRecord.loggerName));
     expect(map2["level"], equals(logRecord.level.name));


### PR DESCRIPTION
dart:json no longer exists so logging_handlers is not functional with the latest sdk
